### PR TITLE
fix title tag of index.htm

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <head>
-  <title>ﾌﾚｰﾑ使用例</title>
+  <title>ＫＭＣのﾎｰﾑﾍﾟｰｼﾞ</title>
   <script src="js/welcome.js"></script>
 </head>
  <frameset cols="250,*" frameborder="yes" border="10" bordercolor="pink">


### PR DESCRIPTION
Firefoxでindex.htmを見た時にページタイトルが「ﾌﾚｰﾑの使用例」だったので修正してみた
